### PR TITLE
Transform decorator

### DIFF
--- a/aligned/compiler/model.py
+++ b/aligned/compiler/model.py
@@ -584,10 +584,9 @@ def compile_with_metadata(model: Any, metadata: ModelMetadata) -> ModelSchema:
     if not probability_features and inference_view.classification_targets:
         inference_view.features.update({target.feature for target in inference_view.classification_targets})
 
-    schema_hash = inference_view.schema_hash()
-
+    view = inference_view.as_view(metadata.name)
     if inference_view.source:
-        inference_view.source = inference_view.source.with_schema_version(schema_hash)
+        inference_view.source = inference_view.source.with_view(view)
 
     return ModelSchema(
         name=metadata.name,

--- a/aligned/data_source/batch_data_source.py
+++ b/aligned/data_source/batch_data_source.py
@@ -18,10 +18,12 @@ import polars as pl
 
 import logging
 
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from aligned.retrival_job import RetrivalJob
+    from aligned.schemas.feature_view import CompiledFeatureView
 
 T = TypeVar('T')
 
@@ -113,7 +115,7 @@ class BatchDataSource:
         """
         return self.job_group_key()
 
-    def with_schema_version(self: T, schema_hash: bytes) -> T:
+    def with_view(self: T, view: CompiledFeatureView) -> T:
         return self
 
     def __hash__(self) -> int:
@@ -1051,9 +1053,11 @@ class JoinDataSource(CodableBatchDataSource):
         )
 
     def all_between_dates(
-        self, request: RetrivalRequest, start_date: datetime, end_date: datetime
+        self,
+        request: RetrivalRequest,
+        start_date: datetime,
+        end_date: datetime,
     ) -> RetrivalJob:
-
         right_job = self.right_source.all_data(self.right_request, limit=None).derive_features(
             [self.right_request]
         )

--- a/aligned/data_source/model_predictor.py
+++ b/aligned/data_source/model_predictor.py
@@ -39,13 +39,18 @@ class PredictModelSource(BatchDataSource):
                 f'Type: {type(self)} have not implemented how to load fact data with multiple sources.'
             )
 
-        location = reqs.needed_requests[0].location
+        req = reqs.needed_requests[0]
+        location = req.location
         if location.location_type != 'feature_view':
             raise NotImplementedError(
                 f'Type: {type(self)} have not implemented how to load fact data with multiple sources.'
             )
 
-        entities = self.store.store.feature_view(location.name).all_columns(limit=limit)
+        entities = (
+            self.store.store.feature_view(location.name)
+            .select(req.features_to_include)
+            .all_columns(limit=limit)
+        )
         return self.store.predict_over(entities).with_request([request])
 
     def all_between_dates(
@@ -57,13 +62,18 @@ class PredictModelSource(BatchDataSource):
                 f'Type: {type(self)} have not implemented how to load fact data with multiple sources.'
             )
 
-        location = reqs.needed_requests[0].location
+        req = reqs.needed_requests[0]
+        location = req.location
         if location.location_type != 'feature_view':
             raise NotImplementedError(
                 f'Type: {type(self)} have not implemented how to load fact data with multiple sources.'
             )
 
-        entities = self.store.store.feature_view(location.name).between_dates(start_date, end_date)
+        entities = (
+            self.store.store.feature_view(location.name)
+            .select(req.features_to_include)
+            .between_dates(start_date, end_date)
+        )
         return self.store.predict_over(entities).with_request([request])
 
     def features_for(self, facts: RetrivalJob, request: RetrivalRequest) -> RetrivalJob:

--- a/aligned/exposed_model/interface.py
+++ b/aligned/exposed_model/interface.py
@@ -373,7 +373,7 @@ def ab_test_model(models: list[tuple[ExposedModel, float]]) -> ABTestModel:
 
 
 @dataclass
-class DillFunction(ExposedModel):
+class DillFunction(ExposedModel, VersionedModel):
 
     function: bytes
 
@@ -386,6 +386,11 @@ class DillFunction(ExposedModel):
     @property
     def as_markdown(self) -> str:
         return 'A function stored in a dill file.'
+
+    async def model_version(self) -> str:
+        from hashlib import md5
+
+        return md5(self.function, usedforsecurity=False).hexdigest()
 
     async def needed_features(self, store: ModelFeatureStore) -> list[FeatureReference]:
         default = store.model.features.default_version

--- a/aligned/feature_view/feature_view.py
+++ b/aligned/feature_view/feature_view.py
@@ -722,9 +722,6 @@ class FeatureView(ABC):
             else:
                 view.features.add(compiled_feature)
 
-        if not view.entities:
-            raise ValueError(f'FeatureView {metadata.name} must contain at least one Entity')
-
         loc = FeatureLocation.feature_view(view.name)
         aggregation_group_by = [FeatureReference(entity.name, loc, entity.dtype) for entity in view.entities]
         event_timestamp_ref = (
@@ -746,11 +743,10 @@ class FeatureView(ABC):
             )
             view.aggregated_features.add(feat)
 
-        schema_hash = view.schema_hash()
-        view.source = view.source.with_schema_version(schema_hash)
+        view.source = view.source.with_view(view)
 
         if view.materialized_source:
-            view.materialized_source = view.materialized_source.with_schema_version(schema_hash)
+            view.materialized_source = view.materialized_source.with_view(view)
 
         return view
 

--- a/aligned/jobs/tests/test_combined_job.py
+++ b/aligned/jobs/tests/test_combined_job.py
@@ -1,6 +1,41 @@
 import pytest
 
+from aligned import feature_view, String, Bool
+from aligned.sources.in_mem_source import InMemorySource
 from aligned.retrival_job import CombineFactualJob, RetrivalJob, RetrivalRequest
+from aligned.compiler.feature_factory import transform_polars, transform_pandas, transform_row
+
+import polars as pl
+from aligned.lazy_imports import pandas as pd
+
+
+@feature_view(source=InMemorySource.empty())
+class CombinedData:
+    query = String()
+    contains_mr = query.contains('mr')
+
+    @transform_polars(using_features=[query], return_type=Bool())
+    def contains_something(self, df: pl.LazyFrame, return_value: str) -> pl.LazyFrame:
+        return df.with_columns((pl.col('query').str.len_chars() > 5).alias(return_value))
+
+    @transform_pandas(using_features=[query], return_type=String())
+    def append_someting(self, df: pd.DataFrame) -> pd.Series:
+        return df['query'] + ' something'
+
+    @transform_row(using_features=[query], return_type=String())
+    def using_row(self, row: dict) -> str:
+        return row['query'] + ' something'
+
+    not_contains = contains_something.not_equals(True)
+
+
+@pytest.mark.asyncio
+async def test_feature_view_without_entity():
+
+    job = CombinedData.query().features_for({'query': ['Hello', 'Hello mr']})
+    df = await job.to_polars()
+
+    assert df['contains_mr'].sum() == 1
 
 
 @pytest.mark.asyncio

--- a/aligned/jobs/tests/test_derived_job.py
+++ b/aligned/jobs/tests/test_derived_job.py
@@ -212,7 +212,6 @@ async def test_model_with_label_multiple_views() -> None:
     store = feature_store()
     entities = await (store.feature_view('expence').select_columns(['transaction_id', 'user_id']).to_pandas())
 
-    print(entities.columns)
     data_job = store.model('model').with_labels().features_for(entities)
     data = await data_job.to_pandas()
 

--- a/aligned/jobs/tests/test_derived_job.py
+++ b/aligned/jobs/tests/test_derived_job.py
@@ -212,6 +212,7 @@ async def test_model_with_label_multiple_views() -> None:
     store = feature_store()
     entities = await (store.feature_view('expence').select_columns(['transaction_id', 'user_id']).to_pandas())
 
+    print(entities.columns)
     data_job = store.model('model').with_labels().features_for(entities)
     data = await data_job.to_pandas()
 

--- a/aligned/retrival_job.py
+++ b/aligned/retrival_job.py
@@ -762,7 +762,7 @@ class RetrivalJob(ABC):
         requests = requests or self.retrival_requests
 
         for request in requests:
-            if len(request.derived_features) > 0:
+            if request.derived_features:
                 return DerivedFeatureJob(job=self, requests=requests)
         return self
 

--- a/aligned/schemas/model.py
+++ b/aligned/schemas/model.py
@@ -93,13 +93,13 @@ class PredictionsView(Codable):
                 return feature
         return None
 
-    def as_view(self, name: str) -> CompiledFeatureView | None:
-        if not self.source:
-            return None
+    def as_view(self, name: str) -> CompiledFeatureView:
+        from aligned.sources.in_mem_source import InMemorySource
+        import polars as pl
 
         return CompiledFeatureView(
             name=name,
-            source=self.source,
+            source=self.source or InMemorySource(pl.DataFrame()),
             entities=self.entities,
             features=self.features,
             derived_features=self.derived_features,

--- a/aligned/sources/azure_blob_storage.py
+++ b/aligned/sources/azure_blob_storage.py
@@ -15,6 +15,7 @@ from aligned.local.job import FileDateJob, FileFactualJob, FileFullJob
 from aligned.retrival_job import RetrivalJob, RetrivalRequest
 from aligned.schemas.date_formatter import DateFormatter
 from aligned.schemas.feature import FeatureType, EventTimestamp
+from aligned.schemas.feature_view import CompiledFeatureView
 from aligned.sources.local import (
     CsvConfig,
     DataFileReference,
@@ -352,7 +353,8 @@ Path: *{self.path}*
     def storage(self) -> Storage:
         return self.config.storage
 
-    def with_schema_version(self, schema_hash: bytes) -> AzureBlobCsvDataSource:
+    def with_view(self, view: CompiledFeatureView) -> AzureBlobCsvDataSource:
+        schema_hash = view.schema_hash()
         return AzureBlobCsvDataSource(
             config=self.config,
             path=self.path.replace(AzureBlobDirectory.schema_placeholder(), schema_hash.hex()),
@@ -483,7 +485,8 @@ Partition Keys: *{self.partition_keys}*
     def __hash__(self) -> int:
         return hash(self.job_group_key())
 
-    def with_schema_version(self, schema_hash: bytes) -> AzureBlobPartitionedParquetDataSource:
+    def with_view(self, view: CompiledFeatureView) -> AzureBlobPartitionedParquetDataSource:
+        schema_hash = view.schema_hash()
         return AzureBlobPartitionedParquetDataSource(
             config=self.config,
             directory=self.directory.replace(AzureBlobDirectory.schema_placeholder(), schema_hash.hex()),
@@ -688,10 +691,10 @@ Path: *{self.path}*
     def __hash__(self) -> int:
         return hash(self.job_group_key())
 
-    def with_schema_version(self, schema_hash: bytes) -> AzureBlobParquetDataSource:
+    def with_view(self, view: CompiledFeatureView) -> AzureBlobParquetDataSource:
         return AzureBlobParquetDataSource(
             config=self.config,
-            path=self.path.replace(AzureBlobDirectory.schema_placeholder(), schema_hash.hex()),
+            path=self.path.replace(AzureBlobDirectory.schema_placeholder(), view.schema_hash().hex()),
             mapping_keys=self.mapping_keys,
             parquet_config=self.parquet_config,
             date_formatter=self.date_formatter,

--- a/aligned/sources/local.py
+++ b/aligned/sources/local.py
@@ -27,6 +27,7 @@ from aligned.schemas.date_formatter import DateFormatter
 if TYPE_CHECKING:
     from datetime import datetime
     from aligned.schemas.repo_definition import RepoDefinition
+    from aligned.schemas.feature_view import CompiledFeatureView
     from aligned.feature_store import ContractStore
 
 
@@ -184,7 +185,8 @@ class CsvFileSource(
     def __hash__(self) -> int:
         return hash(self.job_group_key())
 
-    def with_schema_version(self, schema_hash: bytes) -> CsvFileSource:
+    def with_view(self, view: CompiledFeatureView) -> CsvFileSource:
+        schema_hash = view.schema_hash()
         return CsvFileSource(
             path=self.path.replace(FileDirectory.schema_placeholder(), schema_hash.hex()),
             mapping_keys=self.mapping_keys,
@@ -435,7 +437,8 @@ class PartitionedParquetFileSource(
     def __hash__(self) -> int:
         return hash(self.job_group_key())
 
-    def with_schema_version(self, schema_hash: bytes) -> PartitionedParquetFileSource:
+    def with_view(self, view: CompiledFeatureView) -> PartitionedParquetFileSource:
+        schema_hash = view.schema_hash()
         return PartitionedParquetFileSource(
             directory=self.directory.replace(FileDirectory.schema_placeholder(), schema_hash.hex()),
             partition_keys=self.partition_keys,
@@ -588,7 +591,8 @@ class ParquetFileSource(CodableBatchDataSource, ColumnFeatureMappable, DataFileR
 
 [Go to file]({self.path})'''  # noqa
 
-    def with_schema_version(self, schema_hash: bytes) -> ParquetFileSource:
+    def with_view(self, view: CompiledFeatureView) -> ParquetFileSource:
+        schema_hash = view.schema_hash()
         return ParquetFileSource(
             path=self.path.replace(FileDirectory.schema_placeholder(), schema_hash.hex()),
             mapping_keys=self.mapping_keys,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aligned"
-version = "0.0.105"
+version = "0.0.106"
 description = "A data managment and lineage tool for ML applications."
 authors = ["Mats E. Mollestad <mats@mollestad.no>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Made it easier to add different types of udfs

```python
@feature_view(source=InMemorySource.empty())
class CombinedData:
    query = String()
    contains_mr = query.contains('mr')

    @transform_polars(using_features=[query], return_type=Bool())
    def contains_something(self, df: pl.LazyFrame, return_value: str) -> pl.LazyFrame:
        return df.with_columns((pl.col('query').str.len_chars() > 5).alias(return_value))

    @transform_pandas(using_features=[query], return_type=String())
    def append_someting(self, df: pd.DataFrame) -> pd.Series:
        return df['query'] + ' something'

    @transform_row(using_features=[query], return_type=String())
    def using_row(self, row: dict) -> str:
        return row['query'] + ' something'

    not_contains = contains_something.not_equals(True)
```

Also made it easier to switch between a model's output source and when to use the exposed model with 
```python
# Reading from the output source
using_source = store.model(MyModel).predict_over(...)

# Sending the input features to a model
use_model_store = store.without_model_cache()
preds_sent_to_model = use_model_store.model(MyModel).predict_over(...)
```